### PR TITLE
add event template field to list attendees by name

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -30,15 +30,16 @@ The content above will be inserted for a selected event. To customize, create a 
 
 Fields are variables enclosed in `{{` `}}` and will be replaced when the content is generated.
 
-| Field       | Description                                                                                                                                                             |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| start       | The event start time                                                                                                                                                    |
-| summary     | Event title                                                                                                                                                             |
-| description | Event description                                                                                                                                                       |
-| link        | This will produce a link to the Google calendar event. Useful to reference attachment in the event or other event info                                                  |
-| organizer   | The email of the event organizer                                                                                                                                        |
-| attendees   | Email(s) of all attendees, joined by `,`. If the attendee had declined the event, a `(x)` will appear near their email. A tentative response will have a `(?)` appended |
-| source      | will return the google account from where this event was fetched                                                                                                        |
+| Field          | Description                                                                                                                                                             |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| start          | The event start time                                                                                                                                                    |
+| summary        | Event title                                                                                                                                                             |
+| description    | Event description                                                                                                                                                       |
+| link           | This will produce a link to the Google calendar event. Useful to reference attachment in the event or other event info                                                  |
+| organizer      | The email of the event organizer                                                                                                                                        |
+| attendees      | Email(s) of all attendees, joined by `,`. If the attendee had declined the event, a `(x)` will appear near their email. A tentative response will have a `(?)` appended |
+| attendees.name | Similar to `attendees` but will replace the email with the name of the attendee. If the name is not available for an attendee, the email is returned instead.           |
+| source         | will return the google account from where this event was fetched                                                                                                        |
 
 ### Customizing Template
 

--- a/src/api/google/calendar-search.ts
+++ b/src/api/google/calendar-search.ts
@@ -52,7 +52,7 @@ export const searchCalendarEvents = async (
 				endTime: end?.dateTime,
 				attendees:
 					attendees?.map((a) => {
-						return { response: a.responseStatus, email: a.email };
+						return { response: a.responseStatus, email: a.email, name: a.displayName };
 					}) || []
 			};
 		});

--- a/src/models/Event.ts
+++ b/src/models/Event.ts
@@ -32,9 +32,17 @@ export class Event {
 			organizer: this.#event.organizer,
 			attendees: this.#event.attendees
 				.map((a) => {
-					return `${a.email} ${a.response === 'declined' ? '(x)' : a.response === 'tentative' ? '(?)' : ''}`;
+					return `${a.email}${a.response === 'declined' ? ' (x)' : a.response === 'tentative' ? ' (?)' : ''}`;
 				})
 				.join(', '),
+			'attendees.name': this.#event.attendees
+				.map((a) => {
+					return `${a.name ? a.name : a.email}${
+						a.response === 'declined' ? ' (x)' : a.response === 'tentative' ? ' (?)' : ''
+					}`;
+				})
+				.join(', '),
+
 			source: this.#event.accountSource.toLocaleLowerCase()
 		};
 

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -6,6 +6,7 @@ export type EventResult = {
 	organizer: string;
 	attendees: {
 		email: string | undefined | null;
+		name: string | undefined | null;
 		response: string | undefined | null;
 	}[];
 	startTime: string | undefined | null;


### PR DESCRIPTION
new event field {{attendees.name}} returns all attendee names.  if name not available, return email address