### PR TITLE
Allow for a custom event start date format

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ export default class GoogleLookupPlugin extends Plugin {
 			}).open();
 		});
 		this.addCommandIfMarkdownView('Insert Event Info', 'insert-event-info', () => {
-			new EventSuggestModal(this.app, { template: this.settings!.template_file_event }).open();
+			new EventSuggestModal(this.app, { template: this.settings!.template_file_event, dateFormat: this.settings!.event_date_format }).open();
 		});
 
 		this.addSettingTab(new GoogleLookupSettingTab(this.app, this));

--- a/src/models/Event.ts
+++ b/src/models/Event.ts
@@ -6,10 +6,12 @@ import { App, moment } from 'obsidian';
 export class Event {
 	#event: EventResult;
 	#template: string | undefined;
+	#dateFormat: string | undefined;
 
-	constructor(e: EventResult, templateFile: string | undefined) {
+	constructor(e: EventResult, templateFile: string | undefined, dateFormat: string | undefined) {
 		this.#event = e;
 		this.#template = templateFile;
+		this.#dateFormat = dateFormat;
 	}
 
 	generateFromTemplate = async (app: App) => {
@@ -27,7 +29,7 @@ export class Event {
 		const transform = {
 			summary: this.#event.summary,
 			description: this.#event.description,
-			start: startMoment.format('ddd, MMM Do @ hh:mma'),
+			start: startMoment.format(this.#dateFormat ?? 'ddd, MMM Do @ hh:mma'),
 			link: this.#event.htmlLink,
 			organizer: this.#event.organizer,
 			attendees: this.#event.attendees

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -89,6 +89,13 @@ export class GoogleLookupSettingTab extends PluginSettingTab {
 			key: 'template_file_event'
 		});
 
+		this.insertTextInputSetting({
+			name: 'Date Format',
+			description: 'Date format to be used on the start date field.',
+			placeholder: 'ddd, MMM Do @ hh:mma',
+			key: 'event_date_format'
+		});
+
 		containerEl.createEl('h3', { text: 'Google Client' });
 		this.insertTextInputSetting({
 			name: 'Client ID',

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -6,5 +6,6 @@ export type GoogleLookupPluginSettings = {
 	folder_person: string;
 	person_filename_format: string;
 	template_file_event: string;
+	event_date_format: string;
 	rename_person_file: boolean;
 };

--- a/src/ui/calendar-modal.ts
+++ b/src/ui/calendar-modal.ts
@@ -8,6 +8,7 @@ import { AuthModal } from './auth-modal';
 
 type ModalOptions = {
 	template: string | undefined;
+	dateFormat: string | undefined;
 };
 export class EventSuggestModal extends SuggestModal<EventResult> {
 	#initialQuery: moment.Moment;
@@ -58,7 +59,7 @@ export class EventSuggestModal extends SuggestModal<EventResult> {
 
 	async onChooseSuggestion(event: EventResult, evt: MouseEvent | KeyboardEvent) {
 		new Notice(`Inserted info for ${event.summary}`);
-		const e = new Event(event, this.#options.template);
+		const e = new Event(event, this.#options.template, this.#options.dateFormat);
 		insertIntoEditorRange(this.app, await e.generateFromTemplate(this.app));
 	}
 


### PR DESCRIPTION
This is mostly for compatibility with the plugin [lynchjames/obsidian-day-planner](https://github.com/lynchjames/obsidian-day-planner), but is probably useful for other use cases, too.

- Add a configuration option for defining the date format for events.
- Apply the configured date format when fetching calendar events into a note.