### PR TITLE
add json field in template

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -40,6 +40,7 @@ Fields are variables enclosed in `{{` `}}` and will be replaced when the content
 | attendees      | Email(s) of all attendees, joined by `,`. If the attendee had declined the event, a `(x)` will appear near their email. A tentative response will have a `(?)` appended |
 | attendees.name | Similar to `attendees` but will replace the email with the name of the attendee. If the name is not available for an attendee, the email is returned instead.           |
 | source         | will return the google account from where this event was fetched                                                                                                        |
+| json           | returns the entire event object as JSON. this is useful when used with other templating plugins. [see example](/obsidian-google-lookup/person/#using-templater).        |
 
 ### Customizing Template
 

--- a/docs/person.md
+++ b/docs/person.md
@@ -82,7 +82,47 @@ Fields are variables enclosed in `{{` `}}` and will be replaced when the content
 | userData       | user defined key/value pairs. will be returned similar to `clientData`                                                                                                                                         |
 | bio            | the contact's bio; in Google Contacts, that field is called `Notes`                                                                                                                                            |
 | link           | will return the url, if available, to open the contact on Google Contacts                                                                                                                                      |
+| json           | returns the entire contact object as JSON. this is useful when used with other templating plugins. [see example below](#using-templater).                                                                      |
 
 ### Customizing Template
 
 You can create your own template in a file, and include a link to that file in Settings for `Event Template`. For example, you can create a note in `_assets/templates/` called `t_event` and then provide the path `_assets/templates/t_event` in Settings
+
+### Using Templater
+
+You can use the `json` field to get more flexibility with how the info is rendered in your template. This would typically be done with another templates plugin, such as [Templater](https://silentvoid13.github.io/Templater/).
+
+```
+<%*
+ let json = {{json}}
+ let firstName = json.firstName
+ let emails = json.emails.join("\n")
+ let relations = json.relations.map(({person, type}) => `${firstName} is a ${type || ''} relation to ${person}`).join("\n")
+ -%>
+
+ my contact's first name is <% firstName %>
+ emails:
+ <% emails %>
+
+ relations:
+ <% relations %>
+
+ date: <% tp.file.creation_date("YYYY-MM-DD HH:mm:ss") %>
+
+<% tp.file.cursor() %>
+```
+
+The first line brings in the entire object into the `json` variable. From there, you can construct any template for each individual field. When the above Templater snippet is run, it would output something similar to this:
+
+```
+ my contact's first name is Stewie
+ emails:
+ stewie.griffin@baby.example.com
+ stewie@baby.genius.example.com
+
+ relations:
+ Stewie is a child relation to Lois
+ Stewie is a brother relation to Brian
+
+ date: 2022-10-26 14:57:22
+```

--- a/src/models/Event.ts
+++ b/src/models/Event.ts
@@ -45,7 +45,8 @@ export class Event {
 				})
 				.join(', '),
 
-			source: this.#event.accountSource.toLocaleLowerCase()
+			source: this.#event.accountSource.toLocaleLowerCase(),
+			json: JSON.stringify(this.#event, null, 2)
 		};
 
 		for (const [k, v] of Object.entries(transform)) {

--- a/src/models/Person.ts
+++ b/src/models/Person.ts
@@ -52,7 +52,8 @@ export class Person {
 			relations: this.#person.relations?.map((r) => `${r?.type}: ${r?.person}`).join(', ') || '',
 			clientData: this.#person.clientData?.map((c) => `${c?.key}: ${c?.value}`).join(', ') || '',
 			userData: this.#person.userDefinedData?.map((c) => `${c?.key}: ${c?.value}`).join(', ') || '',
-			bio: this.#person.bio ?? ''
+			bio: this.#person.bio ?? '',
+			json: JSON.stringify(this.#person, null, 2)
 		};
 
 		for (const [k, v] of Object.entries(transform)) {


### PR DESCRIPTION
the `json` field returns the entire object in json format.  this is useful to combine with other templating logic, such as using Templater, in order to get more advanced rendering of the content