### PR TITLE
handle urlencoded "/" in oauth code

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
 	"dependencies": {
 		"@googleapis/calendar": "^1.0.2",
 		"@googleapis/people": "^1.0.3"
-	}
+	},
+	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/ui/auth-modal.ts
+++ b/src/ui/auth-modal.ts
@@ -24,7 +24,8 @@ export class AuthModal extends Modal {
 			.createServer(async (req, res) => {
 				const re = /\/\?code=(\d\/[\w|-]*)&/;
 				if (req.url) {
-					const match = req.url.match(re);
+					const url = req.url.replace('%2F', '/');
+					const match = url.match(re);
 					if (match && match?.length > 1) {
 						this.onSubmit(match[1]);
 						setTimeout(() => {


### PR DESCRIPTION
fixes #50

i don't quite get why yet, but in some cases, the google oauth code in the google redirect is encoding the `/` character.  

we previously handled redirect callbacks from Google like:
`http://127.0.0.1:42601/?code=4/0AUJR-ZZZZZZZ`

now I've come across:
`[http://127.0.0.1:42601/?code=4%2F0AUJR-ZZZZZZ`

(the `/` is replaced with `%2F`)