### PR TITLE
feat(events): Add more event fields and lookup by ID

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,105 @@
+# API
+
+This plugin exposes an API that other plugins can use to lookup people and events.
+
+## Enabling the API
+
+For security reasons, the API is disabled by default. A user must explicitly enable it before any other plugin can access it. This is done in the plugin's settings under **Advanced -> Expose API to other plugins**.
+
+Enabling this option requires the user to complete a security confirmation to ensure they understand the risks. Please instruct your users to perform this one-time setup step if your plugin depends on the Google Lookup API.
+
+## Accessing the API
+
+To access the API, you need to get the plugin instance from Obsidian's plugin manager. It is recommended to wait for the plugin to be loaded before accessing the API.
+
+```javascript
+const googleLookupPlugin = app.plugins.plugins['obsidian-google-lookup'];
+if (googleLookupPlugin) {
+  const api = googleLookupPlugin.api;
+  if (api !== undefined) {
+    // You can now use the api object
+  } else {
+    // Handle the case where the API is not available
+    // (the user has not enabled it in settings)
+  }
+} else {
+  // Handle the case where the plugin is not enabled or available
+}
+```
+
+## API Methods
+
+The API object provides the following methods:
+
+### getAccounts()
+
+Returns a list of all configured Google account names.
+
+**Returns:** `Promise<string[]>` - A promise that resolves to an array of account name strings.
+
+**Example:**
+
+```javascript
+const accountNames = await api.getAccounts();
+console.log(accountNames);
+// Output: ['account1@gmail.com', 'account2@work.com']
+```
+
+### people(query, [accountName])
+
+Searches for people in your Google Contacts and Directory.
+
+**Parameters:**
+
+* `query` (string): The search query.
+* `accountName` (string, optional): The name of a specific account to query. If not provided, all accounts will be searched.
+
+**Returns:** `Promise<PersonResult[]>` - A promise that resolves to an array of person results.
+
+### events(query, [accountName])
+
+Searches for events in your Google Calendar.
+
+**Parameters:**
+
+* `query` (moment.Moment): A moment.js object representing the date for which to fetch events.
+* `accountName` (string, optional): The name of a specific account to query. If not provided, all accounts will be searched.
+
+**Returns:** `Promise<EventResult[]>` - A promise that resolves to an array of event results.
+
+## Example
+
+Here is an example of how to use the API from a Templater user script:
+
+```javascript
+async function lookup(tp) {
+  const api = app.plugins.plugins['obsidian-google-lookup']?.api;
+  if (!api) {
+    new Notice("Google Lookup plugin or its API is not enabled.");
+    return;
+  }
+
+  // Get available accounts
+  const accounts = await api.getAccounts();
+  console.log("Available accounts:", accounts);
+
+  const personQuery = await tp.system.prompt("Enter name to search");
+  if (personQuery) {
+    // Search all accounts for a person
+    const allPeople = await api.people(personQuery);
+    console.log("People (all accounts):", allPeople);
+
+    // Or search a specific account if available
+    if (accounts.length > 0) {
+      const peopleInFirstAccount = await api.people(personQuery, accounts[0]);
+      console.log(`People (${accounts[0]}):`, peopleInFirstAccount);
+    }
+  }
+
+  // Search for today's events
+  const todaysEvents = await api.events(moment());
+  console.log("Today's Events:", todaysEvents);
+}
+
+module.exports = lookup;
+```

--- a/docs/events.md
+++ b/docs/events.md
@@ -16,12 +16,17 @@ When nothing has been input yet, the following criteria will be applied as defau
 
 ### Default Template
 
-```
+```markdown
 ### {{summary}}
 
-* {{start}}  - [Link]({{link}})
+* {{start}}-{{end}}: [Link]({{link}})
 * organizer {{organizer}}
 * {{attendees}}
+* {{location}}
+
+{{attachments}}
+
+{{conference}}
 ```
 
 The content above will be inserted for a selected event. To customize, create a new template in a file and reference that file in the plugin settings.
@@ -32,13 +37,22 @@ Fields are variables enclosed in `{{` `}}` and will be replaced when the content
 
 | Field          | Description                                                                                                                                                             |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| start          | The event start time                                                                                                                                                    |
+| id             | The event ID                                                                                                                                                            |
+| recurringId    | The recurring event ID                                                                                                                                                  |
 | summary        | Event title                                                                                                                                                             |
 | description    | Event description                                                                                                                                                       |
+| status         | The event status (e.g. confirmed, tentative, cancelled)                                                                                                                 |
+| eventType      | The event type (e.g. default, focusTime)                                                                                                                                |
+| start          | The event start time                                                                                                                                                    |
+| end            | The event end time                                                                                                                                                      |
 | link           | This will produce a link to the Google calendar event. Useful to reference attachment in the event or other event info                                                  |
 | organizer      | The email of the event organizer                                                                                                                                        |
 | attendees      | Email(s) of all attendees, joined by `,`. If the attendee had declined the event, a `(x)` will appear near their email. A tentative response will have a `(?)` appended |
 | attendees.name | Similar to `attendees` but will replace the email with the name of the attendee. If the name is not available for an attendee, the email is returned instead.           |
+| location       | The event location                                                                                                                                                      |
+| attachments    | A list of attachments for the event, formatted as markdown links.                                                                                                       |
+| conference     | A list of conference entry points for the event, formatted as markdown links.                                                                                           |
+| conference.solution | The name of the conference solution (e.g. Google Meet).                                                                                                             |
 | source         | will return the google account from where this event was fetched                                                                                                        |
 | json           | returns the entire event object as JSON. this is useful when used with other templating plugins. [see example](/obsidian-google-lookup/person/#using-templater).        |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,3 +21,4 @@ nav:
   - 'google-setup.md'
   - 'events.md'
   - 'person.md'
+  - 'api.md'

--- a/src/api/google/calendar-search.ts
+++ b/src/api/google/calendar-search.ts
@@ -16,6 +16,72 @@ export const getCalendarService = async ({ credentials, token }: GoogleServiceOp
 	});
 };
 
+const buildCalendarEvent = (item: calendar_v3.Schema$Event, accountSource: string): EventResult => {
+		const {
+			id,
+			recurringEventId,
+			summary,
+			description,
+			status,
+			eventType,
+			attachments,
+			htmlLink,
+			organizer,
+			attendees,
+			start,
+			end,
+			location,
+			conferenceData
+		} = item;
+		return {
+			id: id as string,
+			recurringId: recurringEventId,
+			summary: summary || '',
+			description: description || '',
+			status: status || '',
+			eventType: eventType || '',
+			accountSource: accountSource,
+			attachments:
+				attachments
+					?.filter((a) => !!a.fileUrl)
+					.map((a) => {
+						return {
+							title: a.title,
+							mimeType: a.mimeType,
+							fileUrl: a.fileUrl as string,
+							iconUrl: a.iconLink
+						};
+					}) || [],
+			htmlLink,
+			organizer: organizer?.email || '',
+			attendees:
+				attendees
+					?.filter((a) => !!a.email)
+					.map((a) => {
+						return {
+							response: a.responseStatus,
+							email: a.email,
+							name: a.displayName
+						};
+					}) || [],
+			startTime: start?.dateTime,
+			endTime: end?.dateTime,
+			location: location || null,
+			conferenceData: {
+				solutionName: conferenceData?.conferenceSolution?.name,
+				entryPoints:
+					conferenceData?.entryPoints
+						?.filter((e) => !!e.entryPointType && !!e.uri)
+						.map((e) => ({
+							entryPointType: e.entryPointType as string,
+							label: e.label,
+							uri: e.uri as string,
+							password: e.password
+						})) || []
+			}
+		};
+};
+
 export const searchCalendarEvents = async (
 	query: moment.Moment,
 	{ service, accountName }: QueryOptions
@@ -39,22 +105,35 @@ export const searchCalendarEvents = async (
 			return [];
 		}
 
-		return response.data.items.map((item): EventResult => {
-			const { summary, description, htmlLink, organizer, start, end, attendees } = item;
-			return {
-				summary: summary || '',
-				description: description || '',
-				accountSource: accountName,
-				htmlLink,
-				organizer: organizer?.email || '',
-				startTime: start?.dateTime,
-				endTime: end?.dateTime,
-				attendees:
-					attendees?.map((a) => {
-						return { response: a.responseStatus, email: a.email, name: a.displayName };
-					}) || []
-			};
+		return response.data.items
+			.filter((item) => !!item.id)
+			.map((item) => buildCalendarEvent(item, accountName));
+	} catch (err: any) {
+		console.warn(`Cannot query calendar service ${err.message}`);
+	}
+};
+
+export const getCalendarEventById = async (
+	eventId: string,
+	{ service, accountName }: QueryOptions
+): Promise<EventResult | undefined> => {
+	try {
+		const response = await service.events.get({
+			calendarId: 'primary',
+			eventId: eventId
 		});
+
+		if (response.status !== 200) {
+			console.warn(`error querying people api ${response.statusText}`);
+			return;
+		}
+
+		if (!response.data) {
+			return;
+		}
+
+		return buildCalendarEvent(response.data, accountName);
+
 	} catch (err: any) {
 		console.warn(`Cannot query calendar service ${err.message}`);
 	}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,77 @@
+
+import { searchContactsAndDirectory, getPeopleService } from '@/api/google/people-search';
+import { searchCalendarEvents, getCalendarService } from '@/api/google/calendar-search';
+import { GoogleAccount } from '@/models/Account';
+import { PersonResult, EventResult } from '@/types';
+import { isApiExposureEnabled } from '@/settings/api-exposure';
+
+export function createApi(): GoogleLookupApi | undefined {
+    if (isApiExposureEnabled()) {
+        return new GoogleLookupApi();
+    }
+    return undefined;
+}
+
+export class GoogleLookupApi {
+	async people(query: string, accountName?: string): Promise<PersonResult[]> {
+		const results: PersonResult[] = [];
+		const allAccounts = GoogleAccount.getAllAccounts();
+		const accounts = accountName ? allAccounts.filter((a) => a.accountName === accountName) : allAccounts;
+
+		for (const account of accounts) {
+			if (!account) {
+				continue;
+			}
+			if (account.token) {
+				account.peopleService = await getPeopleService({
+					credentials: GoogleAccount.credentials,
+					token: account.token
+				});
+			}
+			if (!account.peopleService) {
+				continue;
+			}
+			const accountResults = await searchContactsAndDirectory(query, {
+				service: account.peopleService,
+				accountName: account.accountName
+			});
+			if (accountResults) {
+				results.push(...accountResults);
+			}
+		}
+		return results;
+	}
+
+	async events(query: moment.Moment, accountName?: string): Promise<EventResult[]> {
+		const results: EventResult[] = [];
+		const allAccounts = GoogleAccount.getAllAccounts();
+		const accounts = accountName ? allAccounts.filter((a) => a.accountName === accountName) : allAccounts;
+
+		for (const account of accounts) {
+			if (!account) {
+				continue;
+			}
+			if (account.token) {
+				account.calendarService = await getCalendarService({
+					credentials: GoogleAccount.credentials,
+					token: account.token
+				});
+			}
+			if (!account.calendarService) {
+				continue;
+			}
+			const accountResults = await searchCalendarEvents(query, {
+				service: account.calendarService,
+				accountName: account.accountName
+			});
+			if (accountResults) {
+				results.push(...accountResults);
+			}
+		}
+		return results;
+	}
+
+	async getAccounts(): Promise<string[]> {
+		return GoogleAccount.getAllAccounts().map((account) => account.accountName);
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,9 +6,11 @@ import { EventSuggestModal } from '@/ui/calendar-modal';
 import { DEFAULT_SETTINGS, GoogleLookupSettingTab } from './settings';
 import { GoogleLookupPluginSettings } from './types';
 import { getGoogleCredentials, hasGoogleCredentials } from './settings/google-credentials';
+import { GoogleLookupApi, createApi } from './api';
 
 export default class GoogleLookupPlugin extends Plugin {
 	settings: GoogleLookupPluginSettings | undefined;
+	public api?: GoogleLookupApi;
 
 	addCommandIfMarkdownView(name: string, id: string, func: () => void) {
 		this.addCommand({
@@ -43,6 +45,7 @@ export default class GoogleLookupPlugin extends Plugin {
 		this.addSettingTab(new GoogleLookupSettingTab(this.app, this));
 
 		GoogleAccount.loadAccountsFromStorage();
+		this.api = createApi();
 	}
 
 	onunload() {

--- a/src/settings/api-exposure.ts
+++ b/src/settings/api-exposure.ts
@@ -1,0 +1,10 @@
+const STORAGE_KEY = 'google-lookup:api-exposure';
+
+export function isApiExposureEnabled(): boolean {
+    const storedValue = window.localStorage.getItem(STORAGE_KEY);
+    return storedValue === 'true';
+}
+
+export function setApiExposure(enabled: boolean): void {
+    window.localStorage.setItem(STORAGE_KEY, enabled ? 'true' : 'false');
+}

--- a/src/settings/default-templates.ts
+++ b/src/settings/default-templates.ts
@@ -29,9 +29,14 @@ Phone: {{phones}}
 
 `;
 export const DEFAULT_EVENT_TEMPLATE = `
-### {{summary}} 
+### {{summary}}
 
-* {{start}}  - [Link]({{link}})
-* organizer {{organizer}}  
-* {{attendees}}  
+* {{start}}-{{end}}: [Link]({{link}})
+* organizer {{organizer}}
+* {{attendees}}
+* {{location}}
+
+{{attachments}}
+
+{{conference}}
 `;

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -1,7 +1,17 @@
 export type EventResult = {
+	id: string;
+	recurringId: string | undefined | null;
 	summary: string;
 	description: string;
+	status: string;
+	eventType: string;
 	accountSource: string;
+	attachments: {
+		title: string | undefined | null;
+		mimeType: string | undefined | null;
+		fileUrl: string;
+		iconUrl: string | undefined | null;
+	}[];
 	htmlLink: string | undefined | null;
 	organizer: string;
 	attendees: {
@@ -11,4 +21,14 @@ export type EventResult = {
 	}[];
 	startTime: string | undefined | null;
 	endTime: string | undefined | null;
+	location: string | undefined | null;
+	conferenceData: {
+		solutionName: string | undefined | null;
+		entryPoints: {
+			entryPointType: string;
+			label: string | undefined | null;
+			uri: string;
+			password: string | undefined | null;
+		}[];
+	};
 };

--- a/src/ui/secure-confirm-modal.ts
+++ b/src/ui/secure-confirm-modal.ts
@@ -1,0 +1,64 @@
+import { App, ButtonComponent, Modal, Setting, TextComponent } from 'obsidian';
+
+export class SecureConfirmModal extends Modal {
+    private confirmed = false;
+
+    constructor(
+        app: App,
+        private message: string,
+        private confirmationText: string,
+        private onConfirm: () => void,
+        private onCancel: () => void
+    ) {
+        super(app);
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        let submitButton: ButtonComponent;
+
+        contentEl.createEl('p', { text: this.message });
+        contentEl.createEl('p', { text: `To confirm, please type:` });
+        contentEl.createEl('p').createEl('strong', { text: this.confirmationText });
+
+        new Setting(contentEl)
+            .addText((text) => {
+                text.setPlaceholder(this.confirmationText);
+                text.inputEl.addEventListener('input', () => {
+                    if (submitButton) {
+                        const isMatch = text.getValue().toLowerCase() === this.confirmationText.toLowerCase();
+                        submitButton.setDisabled(!isMatch);
+                        if (isMatch) {
+                            submitButton.setCta();
+                        } else {
+                            submitButton.buttonEl.classList.remove('mod-cta');
+                        }
+                    }
+                });
+            });
+
+        new Setting(contentEl)
+            .addButton((btn) => {
+                submitButton = btn;
+                btn.setButtonText('Confirm')
+                    .setDisabled(true)
+                    .onClick(() => {
+                        this.confirmed = true;
+                        this.onConfirm();
+                        this.close();
+                    });
+            })
+            .addButton((btn) =>
+                btn.setButtonText('Cancel').onClick(() => {
+                    this.close();
+                })
+            );
+    }
+
+    onClose() {
+        if (!this.confirmed) {
+            this.onCancel();
+        }
+        this.contentEl.empty();
+    }
+}


### PR DESCRIPTION
This commit introduces several enhancements to the calendar event functionality.

- Expands the `EventResult` type to include more fields from the Google Calendar API, such as event status, type, attachments, location, and conference data.
- Updates the `searchCalendarEvents` function to populate these new fields.
- Adds a new `getCalendarEventById` function to allow fetching a single calendar event by its ID.
- Makes the new event fields available as template variables in the `Event` model.
- Updates the documentation to include the new template variables.